### PR TITLE
feat: html report with graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,7 @@ exportMeasurements()
 
 // To print out summarised measurements (slowest rendering output, slowest server computation)
 showSummarisedMeasurements()
+
+// To export an html file that visualizes measurements on a timeline
+await exportHtmlReport()
 ```

--- a/sandbox/app.R
+++ b/sandbox/app.R
@@ -1,0 +1,25 @@
+# This app is used for local testing purposes
+
+library(shiny)
+
+long_computation <- function(delay) {
+  Sys.sleep(delay)
+}
+
+ui <- fluidPage(
+  includeScript(
+    path = "../shiny-tic-toc.js"
+  ),
+  textInput(inputId = "name", label = ""),
+  textOutput(outputId = "hello_message", )
+)
+
+server <- function(input, output, session) {
+  output$hello_message <- renderText({
+    long_computation(delay = 2)
+
+    paste0("Hello ", input$name, "!")
+  })
+}
+
+shinyApp(ui, server)

--- a/shiny.tictoc.Rproj
+++ b/shiny.tictoc.Rproj
@@ -1,0 +1,16 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes


### PR DESCRIPTION
**Description:** Adds a function to export an html report with a graph that visualises measurements on a timeline. The goal was to:
1. Visualise the measurements in a way that allows to see which outputs make part of which server calculations
2. To have a "self-contained" report that works without external assets.

The plotting code was adapted from this example in the [echarts gallery](https://echarts.apache.org/examples/en/editor.html?c=custom-profile&random=m3skbniwr8)

**How to test:**
1. Run the sandbox app: `shiny::runApp('sandbox')`
3. Interact with the app (e.g. change the textInput multiple times)
4. In the browser devtools run `await exportHtmlReport()`
5. Open the downloaded html file, you should see a timeline graph (like in the screenshot below)

![image](https://github.com/Appsilon/shiny.tictoc/assets/83692505/c798341f-14f1-4702-a550-7a77d4208d7c)
