### PR TITLE
Measuring custom message handlers

### DIFF
--- a/adr/measuring-custom-handlers.md
+++ b/adr/measuring-custom-handlers.md
@@ -4,13 +4,13 @@
 
 The purpose of this document is to describe challenges related to measuring the time taken by custom message handlers in Shiny and decide on an approach.
 
-The reason why we are considering this is because Shiny apps might be using proxy like objects e.g. `leafletProxy` in their apps and calculations related to proxy objects won't be shown in the `shiny.tictoc` measurements.
+The reason why we are considering this is because Shiny apps might be using proxy like objects e.g. `leafletProxy` in their apps and calculations related to proxy objects won't be shown without tracking the `shiny:message` events.
 
 ## Challenges
 
 ### 1. Custom Message handler events are run before the `shiny:idle` event is triggered
 
-This can be observe by running the following app:
+This can be observed by running the following app:
 
 <details>
 <summary> App Code </summary>
@@ -91,7 +91,7 @@ shinyApp(ui, server)
 
 </details>
 
-Here are the logs that appear after clicking the app button:
+Here are the logs that appear after clicking the _Run slow custom handler_ button:
 
 ```
 shiny:inputchanged (custom_handler_trigger)
@@ -106,10 +106,10 @@ shiny:idle (document)
 
 Which shows that the code of the custom handler is run while processing the `shiny:message` and only after it finishes the `shiny:idle` event is triggered.
 
-As a result the `shiny.tictoc` would show that there was prolonged server activity when processing the message - which is not the case in our example. 
+As a result `shiny.tictoc` would show that there was prolonged server activity when processing the message - which is not the case in our example. 
 
 
-### 2. Custom Message handlers might schedule [macrotasks or microtasks](https://javascript.info/event-loop) potentially leading to unintuitive measurements
+### 2. Custom Message handlers might schedule [macrotasks or microtasks](https://javascript.info/event-loop) potentially leading to unintuitive results
 
 <details>
 <summary> App Code </summary>
@@ -215,7 +215,7 @@ In that case measuring how long processing the `shiny:message` event takes would
 ### 1. Measuring Custom handlers by measuring how long it takes to process the `shiny:message` event
 Pros:
 (+) Users get more context on what is happening in their apps - if they see a short running custom message handler, then there is a high chance it just scheduled a task
-(+) A long server computation can be caused by a slow custom message handler and that would be visible in `shiny.tictoc` reports
+(+) A long server computation in the graph might actually be caused by a slow custom message handler and by including custom message handler measurements, that would be visible in `shiny.tictoc` reports
 
 Cons:
 (-) Users might interpret that while running a custom handler, there was server activity happening
@@ -230,4 +230,4 @@ Cons:
 (-) Users won't be aware of custom handlers running in their apps
 
 ## Selected Solution
-Measuring Custom handlers by measuring how long it takes to process the `shiny:message` event, because showing such information gives additional context. By not showing information we take away from the users the possibility to analyse the measurements on their own, and as potential app developers they know their apps the best.
+Measuring custom handlers by measuring how long it takes to process the `shiny:message` event, because showing such information gives additional context. By not showing information we take away from the users the possibility to analyse the measurements on their own, and as potential app developers they know their apps the best.

--- a/adr/measuring-custom-handlers.md
+++ b/adr/measuring-custom-handlers.md
@@ -1,0 +1,233 @@
+# Measuring Custom Handlers
+
+## Introduction
+
+The purpose of this document is to describe challenges related to measuring the time taken by custom message handlers in Shiny and decide on an approach.
+
+The reason why we are considering this is because Shiny apps might be using proxy like objects e.g. `leafletProxy` in their apps and calculations related to proxy objects won't be shown in the `shiny.tictoc` measurements.
+
+## Challenges
+
+### 1. Custom Message handler events are run before the `shiny:idle` event is triggered
+
+This can be observe by running the following app:
+
+<details>
+<summary> App Code </summary>
+
+```r
+library(shiny)
+
+ui <- fluidPage(
+  tags$script(HTML("
+      function sleep(ms) {
+            var start = new Date().getTime(), expire = start + ms;
+            while (new Date().getTime() < expire) { }
+            return;
+      }
+
+      const shinyMessageTypes = [
+            'shiny:busy',
+            'shiny:idle',
+            'shiny:inputchanged',
+            'shiny:message',
+            'shiny:value',
+            'shiny:error',
+            'shiny:outputinvalidated',
+            'shiny:recalculating',
+            'shiny:recalculated',
+      ]
+
+      function debugEvent(event) {
+            let context;
+
+            if (event.message !== undefined && event.message.custom !== undefined) {
+                  context = Object.keys(event.message.custom)[0];
+            } else if (event.target.id !== undefined) {
+                  context = event.target.id
+            } else {
+                  context = 'document';
+            }
+
+            console.log(`${event.type} (${context})`);
+      }
+
+      $(document).ready(function () {
+            Shiny.addCustomMessageHandler('custom_handler', (message) => {
+                  const element = document.getElementById(message.id);
+
+                  console.log('Sleeping...');
+                  sleep(2000)
+                  console.log('Done sleeping...');
+
+                  element.textContent = `Handler result: Hello ${message.text}!`;
+            });
+
+            // Add debug messages
+            shinyMessageTypes.forEach((messageType) => {
+                  $(document).on(messageType, debugEvent);
+            });
+      })
+
+  ")),
+  textInput(inputId = "name", label = "", placeholder = "Type in your name!"),
+  br(),
+  actionButton(inputId = "custom_handler_trigger", label = "Run slow custom handler"),
+  span(id = "custom_handler_output")
+)
+
+server <- function(input, output, session) {
+  observe({
+    session$sendCustomMessage("custom_handler", list(
+      id = "custom_handler_output",
+      text = input$name
+    ))
+  }) |> bindEvent(input$custom_handler_trigger)
+
+}
+
+shinyApp(ui, server)
+```
+
+</details>
+
+Here are the logs that appear after clicking the app button:
+
+```
+shiny:inputchanged (custom_handler_trigger)
+shiny:message (document)
+shiny:busy (document)
+shiny:message (custom_handler)
+Sleeping...
+Done sleeping...
+shiny:message (document)
+shiny:idle (document)
+```
+
+Which shows that the code of the custom handler is run while processing the `shiny:message` and only after it finishes the `shiny:idle` event is triggered.
+
+As a result the `shiny.tictoc` would show that there was prolonged server activity when processing the message - which is not the case in our example. 
+
+
+### 2. Custom Message handlers might schedule [macrotasks or microtasks](https://javascript.info/event-loop) potentially leading to unintuitive measurements
+
+<details>
+<summary> App Code </summary>
+
+```r
+library(shiny)
+
+ui <- fluidPage(
+  tags$script(HTML("
+      function sleep(ms) {
+            var start = new Date().getTime(), expire = start + ms;
+            while (new Date().getTime() < expire) { }
+            return;
+      }
+
+      const shinyMessageTypes = [
+            'shiny:busy',
+            'shiny:idle',
+            'shiny:inputchanged',
+            'shiny:message',
+            'shiny:value',
+            'shiny:error',
+            'shiny:outputinvalidated',
+            'shiny:recalculating',
+            'shiny:recalculated',
+      ]
+
+      function debugEvent(event) {
+            let context;
+
+            if (event.message !== undefined && event.message.custom !== undefined) {
+                  context = Object.keys(event.message.custom)[0];
+            } else if (event.target.id !== undefined) {
+                  context = event.target.id
+            } else {
+                  context = 'document';
+            }
+
+            console.log(`${event.type} (${context})`);
+      }
+
+      $(document).ready(function () {
+            Shiny.addCustomMessageHandler('custom_handler', (message) => {
+                  console.log('custom_handler started!');
+
+                  setTimeout(() => {
+                        const element = document.getElementById(message.id);
+                        console.log('Sleeping...');
+                        sleep(2000)
+                        console.log('Done sleeping...');
+                        element.textContent = `Handler result: Hello ${message.text}!`;
+                  }, 5000);
+                  console.log('custom_handler ended!');
+            });
+
+            // Add debug messages
+            shinyMessageTypes.forEach((messageType) => {
+                  $(document).on(messageType, debugEvent);
+            });
+      })
+
+  ")),
+  textInput(inputId = "name", label = "", placeholder = "Type in your name!"),
+  br(),
+  actionButton(inputId = "custom_handler_trigger", label = "Run slow custom handler"),
+  span(id = "custom_handler_output")
+)
+
+server <- function(input, output, session) {
+  observe({
+    session$sendCustomMessage("custom_handler", list(
+      id = "custom_handler_output",
+      text = input$name
+    ))
+  }) |> bindEvent(input$custom_handler_trigger)
+
+}
+
+shinyApp(ui, server)
+```
+
+</details>
+
+In this case we get the following logs:
+
+```
+shiny:inputchanged (custom_handler_trigger)
+shiny:message (document)
+shiny:busy (document)
+shiny:message (custom_handler)
+custom_handler started!
+custom_handler ended!
+shiny:message (document)
+shiny:idle (document)
+Sleeping...
+Done sleeping...
+```
+
+In that case measuring how long processing the `shiny:message` event takes would only take into account the task scheduling and not running the actual task.
+
+## Considered Solutions
+
+### 1. Measuring Custom handlers by measuring how long it takes to process the `shiny:message` event
+Pros:
+(+) Users get more context on what is happening in their apps - if they see a short running custom message handler, then there is a high chance it just scheduled a task
+(+) A long server computation can be caused by a slow custom message handler and that would be visible in `shiny.tictoc` reports
+
+Cons:
+(-) Users might interpret that while running a custom handler, there was server activity happening
+
+### 2. Not measuring custom handlers at all
+Pros:
+(+) The graph doesn't show that there was server activity happening while running a custom handler
+(+) We won't show small measurements in case a custom handler just schedules tasks
+
+Cons:
+(-) A long server computation might be caused by a slow custom handler and it won't be showed in the graph and users might be looking for bottlenecks in the wrong place
+(-) Users won't be aware of custom handlers running in their apps
+
+## Selected Solution
+Measuring Custom handlers by measuring how long it takes to process the `shiny:message` event, because showing such information gives additional context. By not showing information we take away from the users the possibility to analyse the measurements on their own, and as potential app developers they know their apps the best.

--- a/sandbox/app.R
+++ b/sandbox/app.R
@@ -10,16 +10,28 @@ ui <- fluidPage(
   includeScript(
     path = "../shiny-tic-toc.js"
   ),
-  textInput(inputId = "name", label = ""),
-  textOutput(outputId = "hello_message", )
+  tags$script(src = "main.js"),
+  textInput(inputId = "name", label = "", placeholder = "Type in your name!"),
+  br(),
+  actionButton(inputId = "long_server_computation", label = "Run slow server computation"),
+  textOutput(outputId = "hello_message", inline = TRUE),
+  br(),
+  actionButton(inputId = "custom_handler_trigger", label = "Run slow custom handler"),
+  span(id = "custom_handler_output")
 )
 
 server <- function(input, output, session) {
-  output$hello_message <- renderText({
-    long_computation(delay = 2)
+  observe({
+    session$sendCustomMessage("custom_handler", list(
+      id = "custom_handler_output",
+      text = input$name
+    ))
+  }) |> bindEvent(input$custom_handler_trigger)
 
-    paste0("Hello ", input$name, "!")
-  })
+  output$hello_message <- renderText({
+    Sys.sleep(2.5)
+    paste0("Server computation result: Hello ", input$name, "!")
+  }) |> bindEvent(input$long_server_computation)
 }
 
 shinyApp(ui, server)

--- a/sandbox/www/main.js
+++ b/sandbox/www/main.js
@@ -1,0 +1,49 @@
+function sleep(ms) {
+      var start = new Date().getTime(), expire = start + ms;
+      while (new Date().getTime() < expire) { }
+      return;
+}
+
+const shinyMessageTypes = [
+      "shiny:busy",
+      "shiny:idle",
+      "shiny:inputchanged",
+      "shiny:message",
+      "shiny:value",
+      "shiny:error",
+      "shiny:outputinvalidated",
+      "shiny:recalculating",
+      "shiny:recalculated",
+]
+
+function debugEvent(event) {
+      let context;
+
+      if (event.message !== undefined && event.message.custom !== undefined) {
+            context = Object.keys(event.message.custom)[0];
+      } else if (event.target.id !== undefined) {
+            context = event.target.id
+      } else {
+            context = "document";
+      }
+
+      console.log(`${event.type} (${context})`);
+}
+
+$(document).ready(function () {
+      Shiny.addCustomMessageHandler('custom_handler', (message) => {
+            const element = document.getElementById(message.id);
+            element.textContent = 'Running handler...'
+
+            console.log("Sleeping...");
+            sleep(2000)
+            console.log("Done sleeping...");
+
+            element.textContent = `Handler result: Hello ${message.text}!`;
+      });
+
+      // Add debug messages
+      shinyMessageTypes.forEach((messageType) => {
+            $(document).on(messageType, debugEvent);
+      });
+})

--- a/shiny-tic-toc.js
+++ b/shiny-tic-toc.js
@@ -11,7 +11,7 @@ function makeEndMarkLabel(id) {
 }
 
 function makeMeasurementLabel(id) {
-  return makeLabel(id, 'measurement')
+  return id;
 }
 
 function startMeasurement(id) {

--- a/shiny-tic-toc.js
+++ b/shiny-tic-toc.js
@@ -202,7 +202,6 @@ function exportMeasurements() {
 function plotMeasurements() {
   const chartDom = document.getElementById('measurementsTimeline');
   const myChart = echarts.init(chartDom);
-  var option;
 
   const measureTypeToColor = new Map()
   measureTypeToColor.set('server_computation', '#7b9ce1');
@@ -263,7 +262,8 @@ function plotMeasurements() {
       }
     );
   }
-  option = {
+
+  const option = {
     tooltip: {
       formatter: function (params) {
         return params.marker + params.name + ': ' + params.value[3] + ' ms ' + `<br>type: ${params.value[4]}`;

--- a/shiny-tic-toc.js
+++ b/shiny-tic-toc.js
@@ -177,14 +177,14 @@ function getMeasurements() {
 }
 
 function prepareCsvData() {
-  const dataHeader = ["measurement_id", "duration (ms)", "start_time", "type"];
+  const dataHeader = ["measurement_id",  "type", "start_time", "duration (ms)"];
 
   const measurementData = getMeasurements()
     .map(measurement => [
       measurement.name,
-      measurement.duration,
+      measurement.type,
       measurement.startTime,
-      measurement.type
+      measurement.duration
     ]);
 
   const csvData = [dataHeader].concat(measurementData);

--- a/shiny-tic-toc.js
+++ b/shiny-tic-toc.js
@@ -236,11 +236,11 @@ function plotMeasurements() {
   );
 
   function renderItem(params, api) {
-    var categoryIndex = api.value(0);
-    var start = api.coord([api.value(1), categoryIndex]);
-    var end = api.coord([api.value(2), categoryIndex]);
-    var height = api.size([0, 1])[1] * 0.6;
-    var rectShape = echarts.graphic.clipRectByRect(
+    const categoryIndex = api.value(0);
+    const start = api.coord([api.value(1), categoryIndex]);
+    const end = api.coord([api.value(2), categoryIndex]);
+    const height = api.size([0, 1])[1] * 0.6;
+    const rectShape = echarts.graphic.clipRectByRect(
       {
         x: start[0],
         y: start[1] - height / 2,


### PR DESCRIPTION
**Description:** This PR adds support for measuring how long it takes to run custom message handlers. This means:

1. The exported `CSV` now contains a `type` column which indicates if something was a _server computation_, _output computation_ or a _computation through a custom message handler_
2. The graph now uses colors to indicate the types of measurements (see screenshot below, **note:** I tried adding a legend but didn't find a way to do it 😞)

![image](https://github.com/Appsilon/shiny.tictoc/assets/83692505/875b6857-7ce8-4185-aea1-e2df61a8dbc5)


Additionally:
1. Small refactoring - extracted functions for starting and ending measurements
2. Removed the `measurement` suffix - it didn't add information and would take space on the y-axis (+ it can confuse users if it's not the id of the actual output or custom handler)

**How to test:**
1. Run the sandbox app: `shiny::runApp('sandbox')`
2. Interact with the app (e.g. change the textInput and click all buttons to simulate both output calculations and custom handler calculations)
3. In the browser devtools run `await exportHtmlReport()`
4. Open the downloaded html file, you should see a timeline graph (similar to the one above)
5. In the browser devtools run `exportMeasurements()` - a CSV file should be downloaded and it should include a `type` column